### PR TITLE
Delete data that LFS was using

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.gz filter=lfs diff=lfs merge=lfs -text

--- a/model/data/films.csv.gz
+++ b/model/data/films.csv.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8be172af93de8bbf3e1e20676006fe51be95577ebccd93645efcb04470efae7
-size 15151607

--- a/model/data/movies.csv.gz
+++ b/model/data/movies.csv.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a950e0536a3f9c60021b7a9dd4cd2cc717d6dc90ab24c7a5645769df190af7ce
-size 29403751

--- a/model/data/ratings.csv.gz
+++ b/model/data/ratings.csv.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7e6dc74fb26af8de72cddbf82fbaed36a11eaebb9a3a8155b12e495c7b23d76
-size 165271704

--- a/model/data/temp_data.md
+++ b/model/data/temp_data.md
@@ -1,0 +1,1 @@
+# temp explanation for using data for model development.  


### PR DESCRIPTION
Because git LFS sucks, we're no longer using it. Git LFS still might be implemented though, but the data is deleted.